### PR TITLE
Add option to disable livethumbnails

### DIFF
--- a/src/Main_Class.ahk
+++ b/src/Main_Class.ahk
@@ -270,14 +270,45 @@ Class Main_Class extends ThumbWindow {
     }
 
     ; The method to make it possible to cycle throw the EVE Windows. Used with the Hotkey Groups
-     Cycle_Hotkey_Groups(Arr, direction,*) {
-        static Index := 0 
+    Cycle_Hotkey_Groups(Arr, direction,*) {
+        static Index := 0, NonLoggedIndex := 0
         length := Arr.Length
 
+        ; Get list of all non-logged in clients
+        nonLoggedClients := []
+        for EveHwnd, GuiObj in This.ThumbWindows.OwnProps() {
+            try {
+                title := WinGetTitle("Ahk_Id " EveHwnd)
+                if (title = "EVE" || title = "") {
+                    nonLoggedClients.Push(EveHwnd)
+                }
+            }
+        }
+
+        ; If current window is a non-logged client, cycle through non-logged clients
+        currentTitle := This.CleanTitle(WinGetTitle("A"))
+        if (currentTitle = "" || WinGetTitle("A") = "EVE") {
+            if (direction == "ForwardsHotkey") {
+                NonLoggedIndex := (NonLoggedIndex >= nonLoggedClients.Length) ? 1 : NonLoggedIndex + 1
+                if (nonLoggedClients.Length > 0) {
+                    This.ActivateEVEWindow(nonLoggedClients[NonLoggedIndex])
+                    return
+                }
+            }
+            else if (direction == "BackwardsHotkey") {
+                NonLoggedIndex := (NonLoggedIndex <= 1) ? nonLoggedClients.Length : NonLoggedIndex - 1
+                if (nonLoggedClients.Length > 0) {
+                    This.ActivateEVEWindow(nonLoggedClients[NonLoggedIndex])
+                    return
+                }
+            }
+        }
+
+        ; Otherwise cycle through logged-in clients as before
         if (direction == "ForwardsHotkey") {
             Try
                 Index := (n := IsActiveWinInGroup(This.CleanTitle(WinGetTitle("A")), Arr)) ? n+1 : 1
-              
+          
             if (Index > length)
                 Index := 1
 
@@ -290,7 +321,7 @@ Class Main_Class extends ThumbWindow {
                                 Index := 1
                         }
                     }
-                This.ActivateEVEWindow(,,This.CleanTitle(Arr[Index]))
+                    This.ActivateEVEWindow(,,This.CleanTitle(Arr[Index]))
                 }
             }
         }
@@ -298,6 +329,7 @@ Class Main_Class extends ThumbWindow {
         else if (direction == "BackwardsHotkey") {
             Try
                 Index := (n := IsActiveWinInGroup(This.CleanTitle(WinGetTitle("A")), Arr)) ? n-1 : length
+
             if (Index <= 0)
                 Index := length
 
@@ -734,4 +766,3 @@ Class Main_Class extends ThumbWindow {
         FileAppend(JSON.Dump(This._JSON, , "    "), "EVE-X-Preview.json")
     }
 }
-

--- a/src/Main_Class.ahk
+++ b/src/Main_Class.ahk
@@ -286,9 +286,17 @@ Class Main_Class extends ThumbWindow {
             }
         }
 
+        ; Get the current active window's full title and clean title
+        activeWinHwnd := WinExist("A")
+        currentFullTitle := WinGetTitle("A")
+        currentTitle := This.CleanTitle(currentFullTitle)
+
+        ; Check if current window is actually a non-logged client
+        isNonLoggedClient := (currentFullTitle = "EVE" || currentFullTitle = "") && WinExist("ahk_id " activeWinHwnd " ahk_exe " This.EVEExe)
+        
         ; If current window is a non-logged client, cycle through non-logged clients
-        currentTitle := This.CleanTitle(WinGetTitle("A"))
-        if (currentTitle = "" || WinGetTitle("A") = "EVE") {
+        if (isNonLoggedClient) {
+            Index := 0
             if (direction == "ForwardsHotkey") {
                 NonLoggedIndex := (NonLoggedIndex >= nonLoggedClients.Length) ? 1 : NonLoggedIndex + 1
                 if (nonLoggedClients.Length > 0) {

--- a/src/Main_Class.ahk
+++ b/src/Main_Class.ahk
@@ -387,22 +387,22 @@ Class Main_Class extends ThumbWindow {
     ;This function updates the Thumbnails and hotkeys if the user switches Charakters in the character selection screen 
     EVENameChange(hwnd, title) {
         if (This.ThumbWindows.HasProp(hwnd)) {
-            ; If title is empty (logged out) and we have a last known character, use that
-            if (title = "" && This.LastKnownCharacters.Has(hwnd)) {
+            ; If title is empty or "EVE" (logged out) and we have a last known character, use that
+            if ((title = "" || title = "EVE") && This.LastKnownCharacters.Has(hwnd)) {
                 This.SetThumbnailText[hwnd] := This.LastKnownCharacters[hwnd]
                 return
             }
             
-            ; If we have a valid character name, store it
+            ; If we have a valid character name (not empty and not "EVE"), store it
             if (title != "" && title != "EVE") {
                 This.LastKnownCharacters[hwnd] := title
+                This.SetThumbnailText[hwnd] := title
             }
 
-            This.SetThumbnailText[hwnd] := title
-            ; moves the Window to the saved positions if any stored, a bit of sleep is usfull to give the window time to move before creating the thumbnail
+            ; moves the Window to the saved positions if any stored
             This.RestoreClientPossitions(hwnd, title)
 
-            if (title = "") {
+            if (title = "" || title = "EVE") {
                 ; Keep existing thumbnail, just update text
                 This.SetThumbnailText[hwnd] := This.LastKnownCharacters.Has(hwnd) 
                     ? This.LastKnownCharacters[hwnd] 
@@ -473,25 +473,26 @@ Class Main_Class extends ThumbWindow {
 
     ; Creates a new thumbnail if a new window got created
     EVE_WIN_Created(Win_Hwnd, Win_Title) {
-        ; Moves the Window to the saved possition if any are stored 
-        This.RestoreClientPossitions(Win_Hwnd, Win_Title)        
-        
         ;Creates the Thumbnail and stores the EVE Hwnd in the array
         If !(This.ThumbWindows.HasProp(Win_Hwnd)) {       
             This.ThumbWindows.%Win_Hwnd% := This.Create_Thumbnail(Win_Hwnd, Win_Title)
             This.ThumbHwnd_EvEHwnd[This.ThumbWindows.%Win_Hwnd%["Window"].Hwnd] := Win_Hwnd
 
             ;if the User is in character selection screen show the window always 
-            if (This.ThumbWindows.%Win_Hwnd%["Window"].Title = "") {
-                This.SetThumbnailText[Win_Hwnd] := Win_Title
-                ;if the Title is just "EVE" that means it is in the Charakter selection screen
-                ;in this case show always the Thumbnail 
+            if (Win_Title = "" || Win_Title = "EVE") {
+                ; Check if we have a last known character name
+                if (This.LastKnownCharacters.Has(Win_Hwnd)) {
+                    This.SetThumbnailText[Win_Hwnd] := This.LastKnownCharacters[Win_Hwnd]
+                } else {
+                    This.SetThumbnailText[Win_Hwnd] := "EVE"
+                }
                 This.ShowThumb(Win_Hwnd, "Show")
                 return
             }  
 
-            ;if the user loged in into a Character then move the Thumbnail to the right possition 
+            ;if the user logged in into a Character then move the Thumbnail to the right position 
             else If (This.ThumbnailPositions.Has(Win_Title)) {
+                This.LastKnownCharacters[Win_Hwnd] := Win_Title  ; Store the character name
                 This.SetThumbnailText[Win_Hwnd] := Win_Title
                 rect := This.ThumbnailPositions[Win_Title]                      
                 This.ThumbMove( rect["x"],

--- a/src/Propertys.ahk
+++ b/src/Propertys.ahk
@@ -39,7 +39,10 @@ class Propertys extends TrayMenu {
 
 
     }
-
+    DisableLiveThumbnail {
+        get => This._JSON["global_Settings"]["DisableLiveThumbnail"]
+        set => This._JSON["global_Settings"]["DisableLiveThumbnail"] := value
+    }
     Minimizeclients_Delay {
         get => This._JSON["global_Settings"]["Minimize_Delay"]
         set => This._JSON["global_Settings"]["Minimize_Delay"] := (value < 50 ? "50" : value)

--- a/src/Settings_Gui.ahk
+++ b/src/Settings_Gui.ahk
@@ -108,7 +108,7 @@
     Global_Settings(visible?) {
         This.S_Gui.Controls.Global_Settings := []
         This.S_Gui.SetFont("s10 w400")
-        This.S_Gui.Controls.Global_Settings.Push This.S_Gui.Add("GroupBox", "x20 y80 h280 w500")
+        This.S_Gui.Controls.Global_Settings.Push This.S_Gui.Add("GroupBox", "x20 y80 h295 w500")
         This.S_Gui.Controls.Global_Settings.Push This.S_Gui.Add("Text", "xp+15 yp+20 Section", "Suspend Hotkeys - Hotkey:")
         This.S_Gui.Controls.Global_Settings.Push This.S_Gui.Add("Text", "xs y+15", "Hotkey activation Scope:")
         This.S_Gui.Controls.Global_Settings.Push This.S_Gui.Add("Text", "xs y+15", "Thumbnail Background Color:")
@@ -117,6 +117,8 @@
         This.S_Gui.Controls.Global_Settings.Push This.S_Gui.Add("Text", "xs y+15", "Thumbnail Snap:")
         This.S_Gui.Controls.Global_Settings.Push This.S_Gui.Add("Text", "xs y+15", "Thumbnail Snap Distance:")
         This.S_Gui.Controls.Global_Settings.Push This.S_Gui.Add("Text", "xs y+15", "Minimize EVE Window Delay:")
+        This.S_Gui.Controls.Global_Settings.Push This.S_Gui.Add("CheckBox", "xs y+15 vDisableLiveThumbnail Checked" This.DisableLiveThumbnail, "Disable Live Thumbnail")
+        This.S_Gui["DisableLiveThumbnail"].OnEvent("Click", (obj, *) => gSettings_EventHandler(obj))
 
         This.S_Gui.Controls.Global_Settings.Push This.S_Gui.Add("Edit", "xs+230 ys-3 w150 Section vSuspend_Hotkeys_Hotkey", This.Suspend_Hotkeys_Hotkey)
         This.S_Gui["Suspend_Hotkeys_Hotkey"].OnEvent("Change", (obj, *) => gSettings_EventHandler(obj))
@@ -206,6 +208,10 @@
             }
             else if (obj.name = "Minimizeclients_Delay") {
                 This.Minimizeclients_Delay := obj.value
+                This.NeedRestart := 1
+            }
+            else if (obj.name = "DisableLiveThumbnail") {
+                This.DisableLiveThumbnail := obj.value
                 This.NeedRestart := 1
             }
             SetTimer(This.Save_Settings_Delay_Timer, -200)
@@ -755,6 +761,7 @@
         This.S_Gui["ThumbnailSnapOn"].value := This.ThumbnailSnap
         This.S_Gui["ThumbnailSnapOff"].value := (This.ThumbnailSnap ? 0 : 1)
         This.S_Gui["ThumbnailSnap_Distance"].value := This.ThumbnailSnap_Distance
+        This.S_Gui["DisableLiveThumbnail"].value := This.DisableLiveThumbnail
 
         ;Client Settings
         This.S_Gui["MinimizeInactiveClients"].value := This.MinimizeInactiveClients

--- a/src/ThumbWindow.ahk
+++ b/src/ThumbWindow.ahk
@@ -23,7 +23,6 @@ Class ThumbWindow extends Propertys {
                 "Ptr", ThumbObj["Window"].Hwnd,	; HWND hWnd
                 "Ptr", This.margins,	; MARGINS *pMarInset
                 )   
- 
 
         ;Set The Opacity who is set in the JSON File, its important to set this on the MainWindow and not on the Thumbnail itself
         WinSetTransparent(This.ThumbnailOpacity)
@@ -35,21 +34,20 @@ Class ThumbWindow extends Propertys {
                     This.ThumbnailStartLocation["width"],
                     This.ThumbnailStartLocation["height"]
                 )
-    
 
-        ;#### Register Thumbnail
-        ; gets the EVE Window sizes
-        WinGetClientPos(, , &W, &H, "ahk_id " Win_Hwnd)
+        if (!This.DisableLiveThumbnail) {
 
-        ; These values for the Thumbnails should not be touched
-        ThumbObj["Thumbnail"] := LiveThumb(Win_Hwnd, ThumbObj["Window"].Hwnd)
-        ThumbObj["Thumbnail"].Source := [0, 0, W, H]
-        ThumbObj["Thumbnail"].Destination := [0, 0, This.ThumbnailStartLocation["width"], This.ThumbnailStartLocation["height"]]
-        ThumbObj["Thumbnail"].SourceClientAreaOnly := True
-        ThumbObj["Thumbnail"].Visible := True
-        ThumbObj["Thumbnail"].Opacity := 255
-        ThumbObj["Thumbnail"].Update()
-
+            WinGetClientPos(, , &W, &H, "ahk_id " Win_Hwnd)
+            ThumbObj["Thumbnail"] := LiveThumb(Win_Hwnd, ThumbObj["Window"].Hwnd)
+            ThumbObj["Thumbnail"].Source := [0, 0, W, H]
+            ThumbObj["Thumbnail"].Destination := [0, 0, This.ThumbnailStartLocation["width"], This.ThumbnailStartLocation["height"]]
+            ThumbObj["Thumbnail"].SourceClientAreaOnly := True
+            ThumbObj["Thumbnail"].Visible := True
+            ThumbObj["Thumbnail"].Opacity := 255
+            ThumbObj["Thumbnail"].Update()
+        } else {
+            ThumbObj["Thumbnail"] := { Update: (*) => 0 }
+        }
 
         ;#### Create the Thumbnail TextOverlay
         ;####


### PR DESCRIPTION
Livethumbnails are causing my eve clients to suddnely crash and close down. I believe this is most likely due to the dwm thumbnail api eve-x is using. Crashes happened at the exact instant a client switch is performed. They have started to happen with latest eve patch on 2025-03-25. I found disabling live thumbnails fix the crashes.

--edit--
I have had no crashes today even with live preview after some long play. So maybe whatever underlaying problem my environment or eve itself may have had, seems to be fixed. Still I think the ability to disable the thumbnails is pretty important because for some situations you simply cannot afford to have crashing clients.